### PR TITLE
Attempt to decode token on whitelisted paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ module.exports = compose(
 )(handle)
 ```
 
-#### with whitlist of paths
+#### with whitelist of paths
+Whitelisted paths make JWT token *optional*. However if valid token is provided it will be  decoded.
 
 ```javascript
 'use strict'

--- a/index.js
+++ b/index.js
@@ -3,32 +3,33 @@ const url = require('url')
 const jwt = require('jsonwebtoken')
 
 module.exports = exports = (secret, whitelist) => (fn) => {
-       
+
     if (!secret) {
         throw Error('micro-jwt-auth must be initialized passing a secret to decode incoming JWT token')
     }
-    
+
     return (req, res) => {
         const bearerToken = req.headers.authorization
         const pathname = url.parse(req.url).pathname
-        
-        if (!(Array.isArray(whitelist) && whitelist.indexOf(pathname) !== -1)) {
-            if (!bearerToken) {
-                res.writeHead(401)
-                res.end('missing Authorization header')
-                return
-            }
-            
-            try {
-                const token = bearerToken.replace('Bearer ', '')
-                req.jwt = jwt.verify(token, secret);
-            } catch(err) {
-                res.writeHead(401)
-                res.end('invalid token in Authorization header')
-                return
+        const whitelisted = Array.isArray(whitelist) && whitelist.indexOf(pathname) >= 0
+
+        if (!bearerToken && !whitelisted) {
+            res.writeHead(401)
+            res.end('missing Authorization header')
+            return
+        }
+
+        try {
+            const token = bearerToken.replace('Bearer ', '')
+            req.jwt = jwt.verify(token, secret)
+        } catch(err) {
+            if (!whitelisted) {
+              res.writeHead(401)
+              res.end('invalid token in Authorization header')
+              return
             }
         }
-        
+
         return fn(req, res)
     }
 }


### PR DESCRIPTION
Just came across the problem when whitelisted paths could still have auth token.
E.g. api/login may need to consider previously logged-in user.

That pull request attempts to decode JWT token even on whitelisted paths. If token is valid it's get assigned to req.jwt, otherwise no error thrown.

Added tests as well.