### PR TITLE
Verify using getKey callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = exports = (secret, whitelist, config = {}) => (fn) => {
         config = whitelist || {}
     }
 
-    return (req, res) => {
+    return async (req, res) => {
         const bearerToken = req.headers.authorization
         const pathname = url.parse(req.url).pathname
         const whitelisted = Array.isArray(whitelist) && whitelist.indexOf(pathname) >= 0
@@ -26,7 +26,10 @@ module.exports = exports = (secret, whitelist, config = {}) => (fn) => {
 
         try {
             const token = bearerToken.replace('Bearer ', '')
-            req.jwt = jwt.verify(token, secret)
+            req.jwt = await new Promise((resolve, reject) => {
+                const callback = (err, decoded) => err ? reject(err) : resolve(decoded)
+                jwt.verify(token, secret, config.verifyOptions, callback)
+            })
         } catch(err) {
             if (!whitelisted) {
               res.writeHead(401)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -11,7 +11,7 @@ test('error throwed if secret undefined', () => {
   ).toThrow('micro-jwt-auth must be initialized passing a secret to decode incoming JWT token')
 });
 
-test('case of request has not authorization header', () => {
+test('case of request has not authorization header', async () => {
 
   const request = {
     headers: {},
@@ -23,14 +23,14 @@ test('case of request has not authorization header', () => {
     end: jest.fn().mockImplementation()
   };
 
-  const result = jwtAuth('mySecret')()(request, response)
+  const result = await jwtAuth('mySecret')()(request, response)
 
   expect(result).toBeUndefined()
   expect(response.writeHead).toHaveBeenCalledWith(401)
   expect(response.end).toHaveBeenCalledWith('missing Authorization header')
 });
 
-test('that all works fine: no errors', () => {
+test('that all works fine: no errors', async () => {
 
   const request = {
     headers: {
@@ -44,7 +44,7 @@ test('that all works fine: no errors', () => {
     end: jest.fn().mockImplementation()
   };
 
-  const result = jwtAuth('mySecret')(() => 'Good job!')(request, response)
+  const result = await jwtAuth('mySecret')(() => 'Good job!')(request, response)
 
   expect(result).toEqual('Good job!')
   expect(response.writeHead).toHaveBeenCalledTimes(0)
@@ -52,7 +52,30 @@ test('that all works fine: no errors', () => {
   expect(request.jwt).toEqual(JWT_CONTENT)
 })
 
-test('wrong bearer case', () => {
+test('that all works fine: no errors (async)', async () => {
+
+  const request = {
+    headers: {
+      authorization: VALID_HEADER
+    },
+    url: 'https://api.cabq.gov/domain/resources/1'
+  }
+
+  const response = {
+    writeHead: jest.fn().mockImplementation(),
+    end: jest.fn().mockImplementation()
+  };
+
+  const getKey = (header, callback) => callback(null, 'mySecret')
+  const result = await jwtAuth(getKey)(() => 'Good job!')(request, response)
+
+  expect(result).toEqual('Good job!')
+  expect(response.writeHead).toHaveBeenCalledTimes(0)
+  expect(response.end).toHaveBeenCalledTimes(0)
+  expect(request.jwt).toEqual(JWT_CONTENT)
+})
+
+test('wrong bearer case', async () => {
 
   const request = {
     headers: {
@@ -66,7 +89,7 @@ test('wrong bearer case', () => {
     end: jest.fn().mockImplementation()
   };
 
-  const result = jwtAuth('mySecret')(() => {})(request, response)
+  const result = await jwtAuth('mySecret')(() => {})(request, response)
 
   expect(result).toBeUndefined()
   expect(response.writeHead).toHaveBeenCalledWith(401)
@@ -74,7 +97,7 @@ test('wrong bearer case', () => {
 
 })
 
-test('no need authorization bearer if whitelisted path', () => {
+test('no need authorization bearer if whitelisted path', async () => {
 
   const request = {
     headers: {},
@@ -86,7 +109,7 @@ test('no need authorization bearer if whitelisted path', () => {
     end: jest.fn().mockImplementation()
   };
 
-  const result = jwtAuth('mySecret', [ '/domain/resources/1' ])(() => 'Good job!')(request, response)
+  const result = await jwtAuth('mySecret', [ '/domain/resources/1' ])(() => 'Good job!')(request, response)
 
   expect(result).toEqual('Good job!')
   expect(response.writeHead).toHaveBeenCalledTimes(0)
@@ -94,7 +117,7 @@ test('no need authorization bearer if whitelisted path', () => {
 
 })
 
-test('decode jwt even for whitelisted path', () => {
+test('decode jwt even for whitelisted path', async () => {
 
   const request = {
     headers: {
@@ -108,7 +131,7 @@ test('decode jwt even for whitelisted path', () => {
     end: jest.fn().mockImplementation()
   };
 
-  const result = jwtAuth('mySecret', [ '/domain/resources/1' ])(() => 'Good job!')(request, response)
+  const result = await jwtAuth('mySecret', [ '/domain/resources/1' ])(() => 'Good job!')(request, response)
 
   expect(result).toEqual('Good job!')
   expect(response.writeHead).toHaveBeenCalledTimes(0)
@@ -116,7 +139,7 @@ test('decode jwt even for whitelisted path', () => {
   expect(request.jwt).toEqual(JWT_CONTENT)
 })
 
-test('do not throw error if jwt is invalid for whitelisted path', () => {
+test('do not throw error if jwt is invalid for whitelisted path', async () => {
 
   const request = {
     headers: {
@@ -130,7 +153,7 @@ test('do not throw error if jwt is invalid for whitelisted path', () => {
     end: jest.fn().mockImplementation()
   };
 
-  const result = jwtAuth('mySecret', [ '/domain/resources/1' ])(() => 'Good job!')(request, response)
+  const result = await jwtAuth('mySecret', [ '/domain/resources/1' ])(() => 'Good job!')(request, response)
 
   expect(result).toEqual('Good job!')
   expect(response.writeHead).toHaveBeenCalledTimes(0)
@@ -138,7 +161,7 @@ test('do not throw error if jwt is invalid for whitelisted path', () => {
   expect(request.jwt).toBeUndefined()
 })
 
-test('custom response, wrong bearer', () => {
+test('custom response, wrong bearer', async () => {
 
   const request = {
     headers: {
@@ -153,13 +176,13 @@ test('custom response, wrong bearer', () => {
   }
 
   const customRes = `${Math.random()}`
-  const result = jwtAuth('mySecret', [], { resAuthInvalid: customRes })(() => {})(request, response)
+  const result = await jwtAuth('mySecret', [], { resAuthInvalid: customRes })(() => {})(request, response)
 
   expect(response.end).toHaveBeenCalledWith(customRes)
 
 })
 
-test('custom response, missing bearer', () => {
+test('custom response, missing bearer', async () => {
 
   const request = {
     headers: {},
@@ -172,7 +195,7 @@ test('custom response, missing bearer', () => {
   }
 
   const customRes = `${Math.random()}`
-  const result = jwtAuth('mySecret', { resAuthMissing: customRes })()(request, response)
+  const result = await jwtAuth('mySecret', { resAuthMissing: customRes })()(request, response)
 
   expect(response.end).toHaveBeenCalledWith(customRes)
 


### PR DESCRIPTION
Makes use of `jwt.verify`'s [async functionality](https://github.com/auth0/node-jsonwebtoken#jwtverifytoken-secretorpublickey-options-callback), also accepts `config.verifyOptions` as options. `jwtAuth` now returns a Promise, which might break builds not using micro.